### PR TITLE
Fix search index issues and updated dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased] - 2021-09-22
-- Changed: added patchwork/utf dependency
+## [Unreleased] - 2021-09-23
+- Changed: invalid characters from pdf files are converted to utf-8
 - Changed: added support for symfony/config:^5.0
-- Fixed: exception when indexing a pdf not working (will only show up in dev mode)
-- Fixed: incorrect encoded pdf file content not lead to error on indexing
+- Fixed: exception when indexing a pdf not working (will now only show up in dev mode)
 - Fixed: missing symfony dependencies
 
 ## [2.6.0] - 2021-03-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - 2021-09-22
 - Changed: added patchwork/utf dependency
+- Changed: added support for symfony/config:^5.0
 - Fixed: exception when indexing a pdf not working (will only show up in dev mode)
 - Fixed: incorrect encoded pdf file content not lead to error on indexing
 - Fixed: missing symfony dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - 2021-09-22
+- Changed: added patchwork/utf dependency
+- Fixed: exception when indexing a pdf not working (will only show up in dev mode)
+- Fixed: incorrect encoded pdf file content not lead to error on indexing
+- Fixed: missing symfony dependencies
+
 ## [2.6.0] - 2021-03-12
 - raised minimum smalot/pdfparser version to 0.18.2
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,13 @@
   "require": {
     "php": "^7.1",
     "contao/core-bundle": "^4.4",
-    "heimrichhannot/contao-utils-bundle": "^2.134"
+    "heimrichhannot/contao-utils-bundle": "^2.134",
+    "patchwork/utf8": "^1.3.2",
+    "symfony/config": "^3.4||^4.0||^5.0",
+    "symfony/console": "^3.4||^4.0",
+    "symfony/event-dispatcher": "^3.4||^4.0",
+    "symfony/http-kernel": "^3.4||^4.0",
+    "symfony/translation:": "^3.4||^4.0"
   },
   "conflict": {
     "smalot/pdfparser": "<0.18.2"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     "php": "^7.1",
     "contao/core-bundle": "^4.4",
     "heimrichhannot/contao-utils-bundle": "^2.134",
-    "patchwork/utf8": "^1.3.2",
     "symfony/config": "^3.4||^4.0||^5.0",
     "symfony/console": "^3.4||^4.0",
     "symfony/event-dispatcher": "^3.4||^4.0",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -25,8 +25,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('huh_search');
+        $treeBuilder = new TreeBuilder('huh_search');
+
+        // Keep compatibility with symfony/config < 4.2
+        if (!method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->root('huh_search');
+        } else {
+            $rootNode = $treeBuilder->getRootNode();
+        }
 
         $rootNode
             ->children()

--- a/src/Indexer/PdfSearchIndexer.php
+++ b/src/Indexer/PdfSearchIndexer.php
@@ -165,7 +165,7 @@ class PdfSearchIndexer
             return;
         }
 
-        if (false === mb_detect_encoding($strContent, null, true)) {
+        if (false === mb_detect_encoding($strContent, 'UTF-8', true)) {
             $strContent = $this->fixUtf8Encoding([$strContent]);
         }
 


### PR DESCRIPTION
This PR fix the internal server error exceptions appear on some pages. It also adds the symfony dependencies to composer.json.

Changed:
- don't throw error on index issues on prod mode
- fix invalid utf encodings before add pdf context to index (which can lead to the index errors)
- add missing symfony dependencies to composer.json 
- add symfony/config v5 compatibility